### PR TITLE
Fix auth bearer

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -16,6 +16,9 @@ app.use(clerkAuth);
 app.use("/proposals", ProposalsRouter);
 app.use("/topics", TopicsRouter);
 app.use("/drafts", DraftsRouter);
+app.use("/health", (req, res) => {
+  res.status(200).json({ message: "Ok" });
+});
 
 app.get("/", (req, res) => {
   res.send("Hello World!");
@@ -23,7 +26,7 @@ app.get("/", (req, res) => {
 
 // 404 handler
 app.use((req, res, next) => {
-  res.status(404).json({error: `route ${req.url} does not exist`});
+  res.status(404).json({ error: `route ${req.url} does not exist` });
 })
 
 export default app;

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,8 @@ import jwt from "jsonwebtoken";
 import { TokenPayload } from "./index";
 
 const whitelist = [
-    { method: 'GET', route: '/proposals' }
+    { method: 'GET', route: '/proposals' },
+    { method: 'GET', route: '/health' },
 ];
 
 async function clerkAuth(req: Request, res: Response, next: NextFunction) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,24 +1,28 @@
-import {Request, Response, NextFunction} from "express";
+import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
-import {TokenPayload} from "./index";
+import { TokenPayload } from "./index";
 
-async function clerkAuth(req : Request, res : Response, next : NextFunction) {
-    const token = req.headers.authorization?.replace("Bearer: ", "");
+const whitelist = [
+    { method: 'GET', route: '/proposals' }
+];
+
+async function clerkAuth(req: Request, res: Response, next: NextFunction) {
+    const token = req.headers.authorization?.replace("Bearer ", "");
     const base64Key = process.env.CLERK_JWT_KEY as string;
     const publicKey = Buffer.from(base64Key, 'base64').toString('ascii');
-    const whitelist = [
-        { method: 'GET', route: '/proposals' }
-    ];
     const isWhitelisted = whitelist.some(
         (item) => item.method === req.method && item.route === req.path
     );
+
     if (isWhitelisted) {
         req.user = {} as TokenPayload;
         return next();
     }
+
     if (token === undefined) {
         return res.status(401).json({ message: "not signed in" });
     }
+
     try {
         const decoded = jwt.verify(token, publicKey) as TokenPayload;
         req.user = decoded;
@@ -28,7 +32,7 @@ async function clerkAuth(req : Request, res : Response, next : NextFunction) {
     }
 }
 
-async function logRequest(req : Request, res : Response, next : NextFunction) {
+async function logRequest(req: Request, res: Response, next: NextFunction) {
     console.log(`
 		${req.method} ${req.url}
 		Body: ${JSON.stringify(req.body)}


### PR DESCRIPTION
I was getting invalid authorization headers on Postman. I think the standard is to add authorization headers without a colon, e.g. `Bearer <token>`.

I can make it a separate PR, but added a `/health` endpoint just to have a sanity check that things are good to go when pinging the API.